### PR TITLE
Fix/add testresouces to xcodeproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ iOSInjectionProject/
 
 .techtrain/config.toml
 node_modules/
+.DS_Store

--- a/ios-stations.xcodeproj/project.pbxproj
+++ b/ios-stations.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		617F70BE29C2BD4B00B7AFFE /* testResources in Resources */ = {isa = PBXBuildFile; fileRef = 617F70BD29C2BD4B00B7AFFE /* testResources */; };
 		BE245141266FBEE00038AD81 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE245140266FBEE00038AD81 /* AppDelegate.swift */; };
 		BE245143266FBEE00038AD81 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE245142266FBEE00038AD81 /* SceneDelegate.swift */; };
 		BE245145266FBEE00038AD81 /* FirstViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE245144266FBEE00038AD81 /* FirstViewController.swift */; };
@@ -41,6 +42,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		617F70BD29C2BD4B00B7AFFE /* testResources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = testResources; sourceTree = "<group>"; };
 		BE24513D266FBEE00038AD81 /* ios-stations.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ios-stations.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE245140266FBEE00038AD81 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BE245142266FBEE00038AD81 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 		BE24513F266FBEE00038AD81 /* ios-stations */ = {
 			isa = PBXGroup;
 			children = (
+				617F70BD29C2BD4B00B7AFFE /* testResources */,
 				BE245140266FBEE00038AD81 /* AppDelegate.swift */,
 				BE7131362685ED0F00E3EAB8 /* Book.swift */,
 				BE245142266FBEE00038AD81 /* SceneDelegate.swift */,
@@ -259,6 +262,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				617F70BE29C2BD4B00B7AFFE /* testResources in Resources */,
 				BE24514D266FBEE10038AD81 /* LaunchScreen.storyboard in Resources */,
 				BE24514A266FBEE10038AD81 /* Assets.xcassets in Resources */,
 				BE245148266FBEE00038AD81 /* Main.storyboard in Resources */,


### PR DESCRIPTION
Swift Railway Station 1 の 問題文において、"testResouces" フォルダが既にあると言っているが、XCode上には表示されない。projectに登録した。

https://techtrain.dev/mypage/railway/4/station/94

> Xcode起動後、アプリメニューバーのXcode → About Xcodeの画面を「station1.png」という名前でスクリーンショットし、ios-stations/testResourcesフォルダ直下に追加する。
> Xcodeのアイコンとバージョンが表記された画面をスクリーンショットしてください。
> ios-stationsフォルダは、プロジェクトルートから一段下にあるios-stationsフォルダになります。既にフォルダの中にtestResourcesフォルダが作成されていますので、自分で新たにtestResourcesフォルダを作成する必要はありません。
