### PR TITLE
動かすsimulatorを12から15に変更

### DIFF
--- a/.techtrain/manifests/station_test.sh
+++ b/.techtrain/manifests/station_test.sh
@@ -5,7 +5,7 @@ clear () {
     rm station_result.xml
 }
 
-set -o pipefail && xcodebuild -project ios-stations.xcodeproj -scheme ios-stations -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 12 Pro" "-only-testing:ios-stationsTests/ios_stationsTests/testStation$1" test &> log.log
+set -o pipefail && xcodebuild -project ios-stations.xcodeproj -scheme ios-stations -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 15 Pro" "-only-testing:ios-stationsTests/ios_stationsTests/testStation$1" test &> log.log
 buildStatus=${PIPESTATUS[0]}
 
 cat log.log | xcpretty --report junit --output station_result.xml > /dev/null 2>&1

--- a/.techtrain/manifests/station_test.sh
+++ b/.techtrain/manifests/station_test.sh
@@ -29,4 +29,3 @@ else
     cat station_result.xml
     clear
     exit 1
-fi

--- a/.techtrain/manifests/station_test.sh
+++ b/.techtrain/manifests/station_test.sh
@@ -29,3 +29,4 @@ else
     cat station_result.xml
     clear
     exit 1
+- fi

--- a/.techtrain/manifests/station_test.sh
+++ b/.techtrain/manifests/station_test.sh
@@ -29,4 +29,4 @@ else
     cat station_result.xml
     clear
     exit 1
-- fi
+fi


### PR DESCRIPTION
xcode15にはsimulator 12がデフォルト存在せず
かつ
ユーザー自身が建てたiphone12 pro simulatorがたまに問題発生するため、
デフォルトの存在するiPhone15 pro にupdate

課題文書の方変更までにはマージNG
不整合が起きます。