### PR TITLE
station5のテストコード全部のソース入っても3000バイトないので2900にしました

### DIFF
--- a/ios-stationsTests/ios_stationsTests.swift
+++ b/ios-stationsTests/ios_stationsTests.swift
@@ -71,7 +71,7 @@ class ios_stationsTests: XCTestCase {
 
         let appUrl = URL(fileURLWithPath: #file).deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("ios-stations/Assets.xcassets/AppIcon.appiconset/Contents.json")
         let data = try XCTUnwrap(try? Data(contentsOf: appUrl), "アプリアイコンが設定されていません")
-        XCTAssertGreaterThan(data.count, 3000, "全てのアプリアイコンが設定されていません")
+        XCTAssertGreaterThan(data.count, 2900, "全てのアプリアイコンが設定されていません")
     }
     
     func testStation6() throws {


### PR DESCRIPTION
ユーザーさんが起きた問題と同じ、自分もローカルで見て2918のサイズでした。
<img width="657" alt="image" src="https://github.com/user-attachments/assets/855ddb50-4e8e-4822-91b4-198f9b4ecc4e">
