### PR TITLE
9と17stationのテストケース追加

### DIFF
--- a/ios-stationsTests/ios_stationsTests.swift
+++ b/ios-stationsTests/ios_stationsTests.swift
@@ -130,12 +130,12 @@ class ios_stationsTests: XCTestCase {
         XCTAssertTrue(actions.count > 0, "ボタンにtouchUpInsideのイベントにactionが登録されていません")
         
         var buttonColor = button.backgroundColor
-        var butonColorChanged = button.backgroundColor
+        var buttonColorChanged = button.backgroundColor
         [0...10].forEach { _ in
             button.tap()
-            butonColorChanged = button.backgroundColor
-            XCTAssertNotEqual(butonColorChanged, buttonColor, "ボタンの色は変わる")
-            buttonColor = butonColorChanged
+            buttonColorChanged = button.backgroundColor
+            XCTAssertNotEqual(buttonColorChanged, buttonColor, "ボタンの色は変わっていません")
+            buttonColor = buttonColorChanged
         }
         XCTAssertEqual(button.titleLabel?.font.fontName, "HelveticaNeue-Light", "ボタンのfontがHelvetica NeueのLightに指定されていない")
     }

--- a/ios-stationsTests/ios_stationsTests.swift
+++ b/ios-stationsTests/ios_stationsTests.swift
@@ -117,7 +117,28 @@ class ios_stationsTests: XCTestCase {
         XCTAssertEqual(titleLabel.font, UIFont(name: "Arial-BoldMT", size: 18), "ボタンのフォントが適切に設定されていません")
     }
     
-    // MARK: station9は面談
+    func testStation9() throws {
+        let vc = try XCTUnwrap(loadInitialViewController(), "StoryboardのInitialViewControllerが設定されていません")
+        XCTAssertTrue(vc is FirstViewController, "FirstViewControllerがInitialViewControllerとして設定されていません")
+        
+        let button = try XCTUnwrap(vc.view.subviews.first(where: { $0 is UIButton }) as? UIButton, "ボタンが作成されていません")
+        
+        guard let actions = button.actions(forTarget: vc, forControlEvent: .touchUpInside) else {
+            XCTFail("UIButtonのtouchUpInsideイベントにメソッドが関連付けされていません")
+            return
+        }
+        XCTAssertTrue(actions.count > 0, "ボタンにtouchUpInsideのイベントにactionが登録されていません")
+        
+        var buttonColor = button.backgroundColor
+        var butonColorChanged = button.backgroundColor
+        [0...10].forEach { _ in
+            button.tap()
+            butonColorChanged = button.backgroundColor
+            XCTAssertNotEqual(butonColorChanged, buttonColor, "ボタンの色は変わる")
+            buttonColor = butonColorChanged
+        }
+        XCTAssertEqual(button.titleLabel?.font.fontName, "HelveticaNeue-Light", "ボタンのfontがHelvetica NeueのLightに指定されていない")
+    }
     
     func testStation10() throws {
         let window = UIWindow()
@@ -315,7 +336,33 @@ class ios_stationsTests: XCTestCase {
         XCTAssertEqual(webView.url?.absoluteString, "https://www.amazon.co.jp/dp/B08FZX8PYW/ref=cm_sw_em_r_mt_dp_7NDC2QCY40JYYR6RE3KJ", "SecondViewControllerのurlに適切な値が設定されていません")
     }
     
-    // MARK: station17は面談
+    func testStation17() throws {
+        let window = UIWindow()
+        let vc = try XCTUnwrap(loadInitialViewController(in: window) as? FirstViewController, "StoryboardのInitialViewControllerが設定されていません")
+        
+        let button = try XCTUnwrap(vc.view.subviews.first(where: { $0 is UIButton }) as? UIButton, "ボタンが作成されていません")
+        
+        guard let actions = button.actions(forTarget: vc, forControlEvent: .touchUpInside) else {
+            XCTFail("UIButtonのtouchUpInsideイベントにメソッドが関連付けされていません")
+            return
+        }
+        XCTAssertTrue(actions.contains(where: {$0.contains("fetchBooks")}), "UIButtonにfetchBooksという名前のメソッドが関連付けされていません")
+        let tableView = try XCTUnwrap(vc.view.subviews.first(where: { $0 is UITableView }) as? UITableView, "UITableViewが作成されていません")
+        guard let refreshControl = tableView.refreshControl else {
+            XCTFail("UITableViewにrefreshControlが設定されていない.")
+            return
+        }
+        vc.books = nil
+        refreshControl.sendActions(for: .valueChanged)
+        
+        let expectation = self.expectation(description: "mock request")
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(30)) {
+            XCTAssertFalse(vc.books?.isEmpty ?? true, "bookは更新されていません")
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 60)
+        
+    }
 }
 
 extension XCTestCase {

--- a/ios-stationsTests/ios_stationsTests.swift
+++ b/ios-stationsTests/ios_stationsTests.swift
@@ -129,15 +129,15 @@ class ios_stationsTests: XCTestCase {
         }
         XCTAssertTrue(actions.count > 0, "ボタンにtouchUpInsideのイベントにactionが登録されていません")
         
-        let ramdomColor = UIColor.random
+        let randomColor = UIColor.random
         var red: CGFloat = 0
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
 
-        if ramdomColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
-            XCTAssertFalse(green == 1 && blue == 1 && alpha == 1, "UIColorのrandomでRGBともにramdomする実装がされていません")
-            XCTAssertFalse(green == red || blue == red, "UIColorのrandomでRGBそれぞれ独立したramdomの実装がされていません")
+        if randomColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha) {
+            XCTAssertFalse(green == 1 && blue == 1 && alpha == 1, "UIColorのrandomでRGBともにrandomする実装がされていません")
+            XCTAssertFalse(green == red || blue == red, "UIColorのrandomでRGBそれぞれ独立したrandomの実装がされていません")
         } else {
             XCTAssert(true, "色取得失敗")
         }


### PR DESCRIPTION
### station9
#### 完成条件変更
1. @ IBActionとして定義したメソッドをStoryboardのインスペクタ経由で接続する
1. 既存メソッド呼び出してClickボタンタップすることでボタンの背景をランダムに変更できる
1. Clickボタンのラベルのフォントを指定されたフォント（Helvetica Neue）、スタイル（Light）に変更できる

#### 悩み点
- IBAction経由か普通にコードでinstance生成かはテストコードだけでは区別できず
- 背景ランダム変更のテストコードが厳密ではない
    - 今は3回変更して２回変わっていたらOKにしていた
    - いろんな方法試したけど別の方法でやろうとすると勉強する人が実装しにくくなる

### station17
#### やること変更
1. ボタンを押してデータ取得する機能を実装する
    * @IBActionsの属性を持つfetchBooksという名前のメソッドを定義し、そのメソッドにデータ取得処理を実装してください
    * ボタンのtouchUpInsideイベントでfetchBooksメソッドを呼び出し、データ取得ができるように関連付けを設定してください
    * 取得したデータは画面に追加で反映させましょう
2. 一覧画面からスクロールしてデータ取得する機能を実装する
    * UITableViewインスタンスにUIRefreshControlを追加します
    * UIRefreshControlのイベントと通信処理を接続しましょう
    * PullToRefreshした時は最初の10を取得し直し、その取得した10件のみ表示するように画面をリセットしましょう
3. Station No.1 と同じようにクリア判定を実行する。

#### 完成条件変更
- UIButtonが配置され、ボタンのtouchUpInsideイベントにfetchBooksメソッドの関連付けが設定されている
- UIButtonタップすることでデータが追加されること
- UIRefreshControlがUITableViewに追加されている
- UIRefreshControlにPullToRefreshが機能しデータを取得し直していること

#### 悩み点
- pull refreshの機能をAPI更新をtimeout待ちで30秒後確認しています
    - ネットワークにより判定が支障出る可能性がある
- bookがnetworkからの更新であることの保証はない