### PR TITLE
クリア判定時使用するdeviceを自動選択する

### DIFF
--- a/.techtrain/manifests/station_test.sh
+++ b/.techtrain/manifests/station_test.sh
@@ -5,7 +5,14 @@ clear () {
     rm station_result.xml
 }
 
-set -o pipefail && xcodebuild -project ios-stations.xcodeproj -scheme ios-stations -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 15 Pro" "-only-testing:ios-stationsTests/ios_stationsTests/testStation$1" test &> log.log
+DEVICE_NAME=$(xcrun simctl list devices | grep 'iPhone' | grep -v 'iPhone SE' | sed -E 's/^ *([^()]+) \(([A-F0-9-]+)\) \(.*$/\1 \2/' | sort -k2 -r | head -n 1 | awk '{print $NF}')
+
+if [ -z "$DEVICE_NAME" ]; then
+  echo "Error: No Booted iOS Simulator device found."
+  exit 1
+fi
+
+set -o pipefail && xcodebuild -project ios-stations.xcodeproj -scheme ios-stations -sdk iphonesimulator -destination "platform=iOS Simulator,id=$DEVICE_NAME" "-only-testing:ios-stationsTests/ios_stationsTests/testStation$1" test &> log.log
 buildStatus=${PIPESTATUS[0]}
 
 cat log.log | xcpretty --report junit --output station_result.xml > /dev/null 2>&1

--- a/.techtrain/manifests/station_test.sh
+++ b/.techtrain/manifests/station_test.sh
@@ -24,7 +24,7 @@ if [ $reportRowCount -le 2 ]; then
         # テスト通過
         cat station_result.xml
         clear
-        exit 0        
+        exit 0
     else
         # コンパイルエラー
         cat ios-stationsTests/junit_compile_error.xml


### PR DESCRIPTION
クリア判定時使用するdeviceを自動選択する
- 全部端末からiphoneを探す
- iphoneからSE排除して数値が一番高い方を探す
- 探した行でIDを取得する
- シミュレーターのIDをxcodebuildに使う